### PR TITLE
Add Coconut

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,13 @@ Awesome list of [Xonsh](https://xon.sh/) contributions ([xontribs](https://xon.s
 * [dracula](https://github.com/agoose77/xontrib-dracula) - Dracula theme for xonsh.
 
 
+## Language extensions
+
+*Changes to the xonsh core language.*
+
+* [coconut](http://coconut-lang.org/) - Use language features from Coconut, a functional-programming-oriented strict superset of Python
+
+
 ## Integrations
 
 * [distributed](https://github.com/xonsh/xontrib-distributed) - The [distributed](https://pypi.org/project/distributed/) parallel computing library hooks for xonsh.

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,7 +100,7 @@ Awesome list of [Xonsh](https://xon.sh/) contributions ([xontribs](https://xon.s
 
 *Changes to the xonsh core language.*
 
-* [coconut](http://coconut-lang.org/) - Use language features from Coconut, a functional-programming-oriented strict superset of Python
+* [coconut](http://coconut-lang.org/) - Use language features from Coconut, a functional-programming-oriented strict superset of Python.
 
 
 ## Integrations


### PR DESCRIPTION
Adds link to [Coconut](http://coconut-lang.org/)—see documentation on Coconut's `xonsh` support [here](https://coconut.readthedocs.io/en/latest/DOCS.html#xonsh-support).